### PR TITLE
Nav backend support

### DIFF
--- a/pkg/plugin/haystackClient.go
+++ b/pkg/plugin/haystackClient.go
@@ -13,4 +13,5 @@ type HaystackClient interface {
 	Eval(string) (haystack.Grid, error)
 	HisReadAbsDateTime(haystack.Ref, haystack.DateTime, haystack.DateTime) (haystack.Grid, error)
 	Read(string) (haystack.Grid, error)
+	Nav(haystack.Val) (haystack.Grid, error)
 }

--- a/src/components/HaystackQueryTypeSelector.tsx
+++ b/src/components/HaystackQueryTypeSelector.tsx
@@ -19,11 +19,17 @@ export function HaystackQueryTypeSelector({ datasource, type, refId, onChange }:
   function queryTypeFromValue(value: string): QueryType | null {
     return queryTypes.find((queryType) => queryType.value === value) ?? null;
   }
+
+  async function defaultQueryTypes(): Promise<QueryType[]> {
+    return new Promise<QueryType[]>((resolve) => { resolve(queryTypes);})
+  }
   
   return (
     <InlineField label="Type">
       <AsyncSelect
-        loadOptions={() => {return datasource?.loadOps(refId) ?? new Promise<QueryType[]>((resolve) => { resolve(queryTypes);})}}
+        loadOptions={() => {
+          return datasource?.loadOps(refId) ?? defaultQueryTypes();
+        }}
         defaultOptions
         value={queryTypeFromValue(type)}
         width={30}

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,20 @@ export interface HaystackQuery extends DataQuery {
   read: string;
 }
 
+// OpsQuery is a query that is used to get the available ops from the datasource.
+export class OpsQuery implements HaystackQuery {
+  type = 'ops';
+  eval = '';
+  hisRead = '';
+  read = '';
+
+  refId: string;
+
+  constructor(refId: string) {
+    this.refId = refId;
+  }
+}
+
 export interface QueryType extends SelectableValue<string> {
   apiRequirements: string[];
 }


### PR DESCRIPTION
Adds go backend data model support for `nav` queries. This is intended to support tree-based HisRead selectors in the future