### PR TITLE
Ref Variable Display Improvements

### DIFF
--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -284,7 +284,7 @@ func (datasource *Datasource) CheckHealth(_ context.Context, req *backend.CheckH
 	if err != nil {
 		return &backend.CheckHealthResult{
 			Status:  backend.HealthStatusError,
-			Message: "Uh oh, something's wrong with the connection",
+			Message: err.Error(),
 		}, err
 	}
 

--- a/src/README.md
+++ b/src/README.md
@@ -68,10 +68,10 @@ To use them, simply enter the value in the input string. Below is an example of 
 You can use the Haystack connector to source new variables. Create a query and then enter the name of the column that
 contains the variable values. If no column is specified, the first one is used.
 
-The value injected by the variable exactly matches the displayed value, with the exception of Ref types, where the
-injected value is only the ID portion (i.e. the dis name is not included in the interpolation). Multiple-select values
-are combined with commas, (`red,blue`), but this may be customized using the
-[advanced variable format options](https://grafana.com/docs/grafana/latest/dashboards/variables/variable-syntax/#advanced-variable-format-options).
+The value injected by the variable exactly matches the displayed value, with the exception of Ref types. Instead, Ref
+types display the "display" portion and inject only the "ID" portion (i.e. `@abc "Site A"` will be displayed as `Site A`
+and provide `@abc` when injected). Multiple-select values are combined with commas, (`red,blue`), but this may be
+customized using the [advanced variable format options](https://grafana.com/docs/grafana/latest/dashboards/variables/variable-syntax/#advanced-variable-format-options).
 
 ### Alerting
 

--- a/src/README.md
+++ b/src/README.md
@@ -66,7 +66,7 @@ To use them, simply enter the value in the input string. Below is an example of 
 ### Query Variables
 
 You can use the Haystack connector to source new variables. Create a query and then enter the name of the column that
-contains the variable values. If no column is specified, the first one is used.
+contains the variable values. If no column is specified, `id` is used if present. Otherwise, the first column is used.
 
 The value injected by the variable exactly matches the displayed value, with the exception of Ref types. Instead, Ref
 types display the "display" portion and inject only the "ID" portion (i.e. `@abc "Site A"` will be displayed as `Site A`

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -98,7 +98,7 @@ export class DataSource extends DataSourceWithBackend<HaystackQuery, HaystackDat
 
   // This is called when the user is selecting a variable value
   async metricFindQuery(variableQuery: HaystackVariableQuery, options?: any) {
-    let request: HaystackQuery = variableQuery.query;
+    let request: HaystackQuery = variableQuery;
     let observable = this.query({ targets: [request] } as DataQueryRequest<HaystackQuery>);
     let response = await firstValueFrom(observable);
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,6 +1,5 @@
 import {
   DataSourceInstanceSettings,
-  CoreApp,
   ScopedVars,
   DataQueryRequest,
   DataFrame,
@@ -11,14 +10,7 @@ import {
 } from '@grafana/data';
 import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
 
-import {
-  HaystackQuery,
-  OpsQuery,
-  HaystackDataSourceOptions,
-  DEFAULT_QUERY,
-  HaystackVariableQuery,
-  QueryType,
-} from './types';
+import { HaystackQuery, OpsQuery, HaystackDataSourceOptions, HaystackVariableQuery, QueryType } from './types';
 import { firstValueFrom } from 'rxjs';
 
 export const queryTypes: QueryType[] = [
@@ -132,10 +124,6 @@ export class DataSource extends DataSourceWithBackend<HaystackQuery, HaystackDat
       });
       return acc.concat(fieldVals);
     }, []);
-  }
-
-  getDefaultQuery(_: CoreApp): Partial<HaystackQuery> {
-    return DEFAULT_QUERY;
   }
 
   // Returns a DataQueryRequest that gets the available ops from the datasource

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -7,6 +7,7 @@ import {
   Field,
   MetricFindValue,
   getDefaultTimeRange,
+  FieldType,
 } from '@grafana/data';
 import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
 
@@ -113,14 +114,20 @@ export class DataSource extends DataSourceWithBackend<HaystackQuery, HaystackDat
       }
 
       let fieldVals = field.values.map((value) => {
-        if (value.startsWith('@')) {
-          // Detect ref using @ prefix, and adjust value to just the Ref
-          let spaceIndex = value.indexOf(' ');
-          let id = value.substring(0, spaceIndex);
-          return { text: value, value: id };
-        } else {
-          // Otherwise, just use the value directly
-          return { text: value, value: value };
+        switch (field.type) {
+          case FieldType.string:
+            if (value.startsWith('@')) {
+              // Detect ref using @ prefix, and adjust value to just the Ref
+              let spaceIndex = value.indexOf(' ');
+              let id = value.substring(0, spaceIndex);
+              let dis = value.substring(spaceIndex + 2, value.length - 1);
+              return { text: dis, value: id };
+            } else {
+              // Otherwise, just use the value directly
+              return { text: value, value: value };
+            }
+          default:
+            return { text: value, value: value };
         }
       });
       return acc.concat(fieldVals);

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -99,10 +99,14 @@ export class DataSource extends DataSourceWithBackend<HaystackQuery, HaystackDat
     }
 
     return response.data.reduce((acc: MetricFindValue[], frame: DataFrame) => {
+      // Default to the first field
       let field = frame.fields[0];
       if (variableQuery.column !== undefined && variableQuery.column !== '') {
         // If a column was input, match the column name
         field = frame.fields.find((field: Field) => field.name === variableQuery.column) ?? field;
+      } else if (frame.fields.some((field: Field) => field.name === 'id')) {
+        // If there is an id column, use that
+        field = frame.fields.find((field: Field) => field.name === 'id') ?? field;
       }
 
       let fieldVals = field.values.map((value) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,9 +28,9 @@ export interface QueryType extends SelectableValue<string> {
   apiRequirements: string[];
 }
 
-export interface HaystackVariableQuery {
-  query: HaystackQuery;
+export interface HaystackVariableQuery extends HaystackQuery {
   column: string;
+  refId: string;
 }
 
 export const DEFAULT_QUERY: Partial<HaystackQuery> = {


### PR DESCRIPTION
Ref variables now exclude the `id` portion in the display value. That is, `@abc "Site A"` will be displayed as `Site A`
and provide `@abc` when injected. Also, variables with no column specified will use `id` by default.