### PR TITLE
feat: add Skip TLS Verify toggle to datasource config

### DIFF
--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	neturl "net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -40,36 +41,52 @@ func NewDatasource(ctx context.Context, settings backend.DataSourceInstanceSetti
 	if jsonErr != nil {
 		return nil, jsonErr
 	}
-	url := options.Url
+	rawURL := options.Url
 	username := options.Username
 
 	// settings contains secure inputs in .DecryptedSecureJSONData in a string:string map
 	password := settings.DecryptedSecureJSONData["password"]
 
-	client := client.NewClient(url, username, password)
-	openErr := client.Open()
+	var insecureHost string
+	if options.SkipTlsVerify {
+		if parsedURL, err := neturl.Parse(rawURL); err == nil {
+			insecureHost = parsedURL.Host
+			registerInsecureHost(insecureHost)
+		}
+	}
+
+	haystackClient := client.NewClient(rawURL, username, password)
+	openErr := haystackClient.Open()
 	if openErr != nil {
+		if insecureHost != "" {
+			unregisterInsecureHost(insecureHost)
+		}
 		return nil, openErr
 	}
-	datasource := Datasource{client: client}
+	datasource := Datasource{client: haystackClient, insecureHost: insecureHost}
 	return &datasource, nil
 }
 
 // Datasource is an example datasource which can respond to data queries, reports
 // its health and has streaming skills.
 type Datasource struct {
-	client HaystackClient
+	client       HaystackClient
+	insecureHost string
 }
 
 type Options struct {
-	Url      string `json:"url"`
-	Username string `json:"username"`
+	Url           string `json:"url"`
+	Username      string `json:"username"`
+	SkipTlsVerify bool   `json:"skipTlsVerify"`
 }
 
 // Dispose here tells plugin SDK that plugin wants to clean up resources when a new instance
 // created. As soon as datasource settings change detected by SDK old datasource instance will
 // be disposed and a new one will be created using NewSampleDatasource factory function.
 func (datasource *Datasource) Dispose() {
+	if datasource.insecureHost != "" {
+		unregisterInsecureHost(datasource.insecureHost)
+	}
 	datasource.client.Close()
 }
 

--- a/pkg/plugin/transport.go
+++ b/pkg/plugin/transport.go
@@ -1,0 +1,62 @@
+package plugin
+
+import (
+	"crypto/tls"
+	"net/http"
+	"sync"
+)
+
+var (
+	insecureHostsMu      sync.RWMutex
+	insecureHostsCount   = map[string]int{}
+	transportOnce        sync.Once
+	originalTransport    http.RoundTripper
+	insecureHTTPTransport http.RoundTripper
+)
+
+// registerInsecureHost marks a URL host as one that should skip TLS verification.
+// On the first call, it replaces http.DefaultTransport with a routing transport that
+// directs insecure hosts to a TLS-skipping transport and all others to the original.
+func registerInsecureHost(host string) {
+	transportOnce.Do(func() {
+		originalTransport = http.DefaultTransport
+		if dt, ok := originalTransport.(*http.Transport); ok {
+			clone := dt.Clone()
+			clone.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402
+			insecureHTTPTransport = clone
+		} else {
+			insecureHTTPTransport = &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // #nosec G402
+			}
+		}
+		http.DefaultTransport = &routingTransport{}
+	})
+
+	insecureHostsMu.Lock()
+	defer insecureHostsMu.Unlock()
+	insecureHostsCount[host]++
+}
+
+// unregisterInsecureHost removes the host from the insecure set when its ref count reaches zero.
+func unregisterInsecureHost(host string) {
+	insecureHostsMu.Lock()
+	defer insecureHostsMu.Unlock()
+	insecureHostsCount[host]--
+	if insecureHostsCount[host] <= 0 {
+		delete(insecureHostsCount, host)
+	}
+}
+
+// routingTransport routes HTTP requests to the appropriate transport based on the target host.
+type routingTransport struct{}
+
+func (t *routingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	insecureHostsMu.RLock()
+	count := insecureHostsCount[req.URL.Host]
+	insecureHostsMu.RUnlock()
+
+	if count > 0 {
+		return insecureHTTPTransport.RoundTrip(req)
+	}
+	return originalTransport.RoundTrip(req)
+}

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEvent } from 'react';
-import { InlineField, Input, SecretInput } from '@grafana/ui';
+import { InlineField, InlineSwitch, Input, SecretInput } from '@grafana/ui';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import { HaystackDataSourceOptions, HaystackSecureJsonData } from '../types';
 
@@ -31,6 +31,10 @@ export function ConfigEditor(props: Props) {
         password: event.target.value,
       },
     });
+  };
+
+  const onSkipTlsVerifyChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onOptionsChange({ ...options, jsonData: { ...options.jsonData, skipTlsVerify: event.target.checked } });
   };
 
   const onResetPassword = () => {
@@ -77,6 +81,9 @@ export function ConfigEditor(props: Props) {
           onReset={onResetPassword}
           onChange={onPasswordChange}
         />
+      </InlineField>
+      <InlineField label="Skip TLS Verify" labelWidth={18} tooltip="Skip TLS certificate verification. Use only for development or trusted networks.">
+        <InlineSwitch value={jsonData.skipTlsVerify || false} onChange={onSkipTlsVerifyChange} />
       </InlineField>
     </div>
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,7 @@ export const DEFAULT_QUERY: Partial<HaystackQuery> = {
 export interface HaystackDataSourceOptions extends DataSourceJsonData {
   url: string;
   username: string;
+  skipTlsVerify?: boolean;
 }
 
 /**


### PR DESCRIPTION
Adds a frontend toggle and backend support for skipping TLS certificate verification.
<img width="844" height="645" alt="image" src="https://github.com/user-attachments/assets/c288ea50-d831-4a7c-b1f0-67ce1523ff7a" />
